### PR TITLE
Allow to configure mail subject

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -43,6 +43,7 @@ return [
         ],
         'site_settings' => [
             'contactus_notify_recipients' => [],
+            'contactus_subject' => '',
             'contactus_html' => '',
             'contactus_confirmation_enabled' => true,
             'contactus_confirmation_subject' => 'Confirmation contact', // @translate

--- a/src/Form/ContactUsFieldset.php
+++ b/src/Form/ContactUsFieldset.php
@@ -34,6 +34,19 @@ class ContactUsFieldset extends Fieldset
                 ],
             ])
             ->add([
+                'name' => 'o:block[__blockIndex__][o:data][subject]',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Mail subject', // @translate
+                    'info' => 'Leave empty to use site settings', // @translate
+                ],
+                'attributes' => [
+                    'id' => 'contactus_subject',
+                    'required' => false,
+                    'placeholder' => 'Leave empty to use site settings', // @translate
+                ],
+            ])
+            ->add([
                 'name' => 'o:block[__blockIndex__][o:data][confirmation_enabled]',
                 'type' => Element\Checkbox::class,
                 'options' => [

--- a/src/Form/SiteSettingsFieldset.php
+++ b/src/Form/SiteSettingsFieldset.php
@@ -29,6 +29,19 @@ info@example2.org', // @translate
                 ],
             ])
             ->add([
+                'name' => 'contactus_subject',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Mail subject', // @translate
+                    'info' => 'Leave empty to use the default value', // @translate
+                ],
+                'attributes' => [
+                    'id' => 'contactus_subject',
+                    'required' => false,
+                    'placeholder' => 'Leave empty to use the default value', // @translate
+                ],
+            ])
+            ->add([
                 'name' => 'contactus_html',
                 'type' => CkeditorInline::class,
                 'options' => [

--- a/src/View/Helper/ContactUs.php
+++ b/src/View/Helper/ContactUs.php
@@ -123,7 +123,7 @@ class ContactUs extends AbstractHelper
                     $mail['fromName'] = $args['name'] ?: null;
                     // Keep compatibility with old versions.
                     $mail['to'] = $this->getNotifyRecipients($options);
-                    $mail['subject'] = sprintf($translate('[Contact] %s'), $this->mailer->getInstallationTitle());
+                    $mail['subject'] = $this->getMailSubject($options);
                     $body = <<<TXT
 A user has contacted you.
 
@@ -344,5 +344,17 @@ TXT;
             ->get('Zend\View\Helper\ViewModel')
             ->getRoot()
             ->getVariable('site');
+    }
+
+    protected function getMailSubject(array $options = [])
+    {
+        if (!empty($options['subject'])) {
+            return $options['subject'];
+        }
+
+        $view = $this->getView();
+        $default = sprintf($view->translate('[Contact] %s'), $this->mailer->getInstallationTitle());
+
+        return $view->siteSetting('contactus_subject', $default);
     }
 }


### PR DESCRIPTION
It's configurable either in the site settings or in the page block
settings. If not configured, the default subject is used.