### PR TITLE
Do not explicitly set 'From' header in sent e-mails

### DIFF
--- a/src/View/Helper/ContactUs.php
+++ b/src/View/Helper/ContactUs.php
@@ -282,7 +282,6 @@ class ContactUs extends AbstractHelper
                         $notifyRecipients = $this->getNotifyRecipients($options);
 
                         $mail = [];
-                        $mail['from'] = reset($notifyRecipients) ?: $view->setting('administrator_email');
                         $mail['to'] = $options['author_email'];
                         $mail['toName'] = null;
                         $mail['reply-to'] = $submitted['email'];
@@ -315,8 +314,6 @@ class ContactUs extends AbstractHelper
                     else {
                         // Send the notification message to administrators.
                         $mail = [];
-                        $mail['from'] = $contactMessage->email();
-                        $mail['fromName'] = $contactMessage->name();
                         $mail['to'] = $this->getNotifyRecipients($options);
                         $mail['subject'] = $this->getMailSubject($options)
                             ?: sprintf($translate('[Contact] %s'), $this->mailer->getInstallationTitle());
@@ -339,10 +336,7 @@ class ContactUs extends AbstractHelper
                                     : sprintf('(%s)', $submitted['from'])
                             );
 
-                            $notifyRecipients = $this->getNotifyRecipients($options);
-
                             $mail = [];
-                            $mail['from'] = reset($notifyRecipients) ?: $view->setting('administrator_email');
                             $mail['to'] = $submitted['from'];
                             $mail['toName'] = $submitted['name'] ?: null;
                             $subject = $options['confirmation_subject'] ?: $this->defaultOptions['confirmation_subject'];
@@ -630,7 +624,6 @@ SQL;
     {
         $view = $this->getView();
         $defaultParams = [
-            'fromName' => null,
             'toName' => null,
             'subject' => sprintf($view->translate('[Contact] %s'), $this->mailer->getInstallationTitle()),
             'body' => null,
@@ -666,10 +659,6 @@ SQL;
         $replyTo = is_array($params['reply-to']) ? $params['reply-to'] : [$params['reply-to']];
         foreach ($replyTo as $r) {
             $message->addReplyTo($r);
-        }
-        if ($params['from']) {
-            $message
-                ->setFrom($params['from'], $params['fromName']);
         }
         try {
             $this->mailer->send($message);


### PR DESCRIPTION
Omeka should not send mail on behalf of a user (anonymous or not). The 'From' header should be either the global setting `administrator_email`, or the value set in config/local.config.php, which is the default behaviour of Omeka.

Fixes #8